### PR TITLE
pass context to trace functions

### DIFF
--- a/paho/client.go
+++ b/paho/client.go
@@ -349,7 +349,7 @@ var (
 )
 
 func (c *Client) write(ctx context.Context, w io.WriterTo) (err error) {
-	t := c.traceSend(w)
+	t := c.traceSend(ctx, w)
 	defer func() {
 		t.done(err)
 	}()
@@ -395,7 +395,7 @@ func (c *Client) reader() {
 	}()
 	ctx := context.Background()
 	for {
-		t := c.traceRecv()
+		t := c.traceRecv(ctx)
 		recv, err := packets.ReadPacket(c.Conn)
 		t.done(recv, err)
 		if err == io.EOF {
@@ -823,7 +823,7 @@ func (c *Client) Publish(ctx context.Context, p *Publish) (_ *PublishResponse, e
 }
 
 func (c *Client) publishQoS0(ctx context.Context, pb *packets.Publish) (_ *PublishResponse, err error) {
-	t := c.tracePublish(pb)
+	t := c.tracePublish(ctx, pb)
 	defer func() {
 		t.done(err)
 	}()
@@ -844,7 +844,7 @@ func (c *Client) publishQoS12(ctx context.Context, pb *packets.Publish) (_ *Publ
 		return nil, err
 	}
 
-	t := c.tracePublish(pb)
+	t := c.tracePublish(ctx, pb)
 	defer func() {
 		t.done(err)
 	}()

--- a/paho/client.go
+++ b/paho/client.go
@@ -2,6 +2,7 @@ package paho
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -573,7 +574,11 @@ func (c *Client) pinger(d time.Duration) {
 }
 
 func (c *Client) fail(ctx context.Context, err error) {
-	c.logCtx(ctx, LevelError, "client failed", func(e *LogEntry) {
+	lvl := LevelError
+	if errors.Is(err, context.Canceled) {
+		lvl = LevelWarn
+	}
+	c.logCtx(ctx, lvl, "client failed", func(e *LogEntry) {
 		e.Error = err
 	})
 	c.close()

--- a/paho/log.go
+++ b/paho/log.go
@@ -1,6 +1,10 @@
 package paho
 
-import "github.com/netdata/paho.golang/packets"
+import (
+	"context"
+
+	"github.com/netdata/paho.golang/packets"
+)
 
 type LogLevel byte
 
@@ -19,7 +23,7 @@ type LogEntry struct {
 	ControlPacket *packets.ControlPacket
 }
 
-func (c *Client) log(level LogLevel, msg string, opts ...func(*LogEntry)) {
+func (c *Client) logCtx(ctx context.Context, level LogLevel, msg string, opts ...func(*LogEntry)) {
 	fn := c.Logger
 	if fn == nil {
 		return
@@ -31,5 +35,9 @@ func (c *Client) log(level LogLevel, msg string, opts ...func(*LogEntry)) {
 	for _, opt := range opts {
 		opt(&e)
 	}
-	fn(e)
+	fn(ctx, e)
+}
+
+func (c *Client) log(level LogLevel, msg string, opts ...func(*LogEntry)) {
+	c.logCtx(context.Background(), level, msg, opts...)
 }

--- a/paho/trace.go
+++ b/paho/trace.go
@@ -1,13 +1,15 @@
 package paho
 
 import (
+	"context"
+
 	"github.com/netdata/paho.golang/packets"
 )
 
 type Trace struct {
-	OnSend    func(*SendStartTrace)
-	OnRecv    func(*RecvStartTrace)
-	OnPublish func(*PublishStartTrace)
+	OnSend    func(context.Context, *SendStartTrace)
+	OnRecv    func(context.Context, *RecvStartTrace)
+	OnPublish func(context.Context, *PublishStartTrace)
 }
 
 type PublishStartTrace struct {
@@ -28,7 +30,7 @@ type PublishDoneTrace struct {
 	Error error
 }
 
-func (c *Client) tracePublish(p *packets.Publish) *PublishStartTrace {
+func (c *Client) tracePublish(ctx context.Context, p *packets.Publish) *PublishStartTrace {
 	fn := c.Trace.OnPublish
 	if fn == nil {
 		return nil
@@ -36,7 +38,7 @@ func (c *Client) tracePublish(p *packets.Publish) *PublishStartTrace {
 	t := PublishStartTrace{
 		Packet: p,
 	}
-	fn(&t)
+	fn(ctx, &t)
 	return &t
 }
 
@@ -50,13 +52,13 @@ type RecvDoneTrace struct {
 	Error      error
 }
 
-func (c *Client) traceRecv() *RecvStartTrace {
+func (c *Client) traceRecv(ctx context.Context) *RecvStartTrace {
 	fn := c.Trace.OnRecv
 	if fn == nil {
 		return nil
 	}
 	var t RecvStartTrace
-	fn(&t)
+	fn(ctx, &t)
 	return &t
 }
 
@@ -82,7 +84,7 @@ type SendDoneTrace struct {
 	Error error
 }
 
-func (c *Client) traceSend(x interface{}) *SendStartTrace {
+func (c *Client) traceSend(ctx context.Context, x interface{}) *SendStartTrace {
 	fn := c.Trace.OnSend
 	if fn == nil {
 		return nil
@@ -91,7 +93,7 @@ func (c *Client) traceSend(x interface{}) *SendStartTrace {
 		Packet:     x,
 		PacketType: matchPacketType(x),
 	}
-	fn(&t)
+	fn(ctx, &t)
 	return &t
 }
 

--- a/paho/trace.go
+++ b/paho/trace.go
@@ -14,14 +14,14 @@ type Trace struct {
 
 type PublishStartTrace struct {
 	Packet *packets.Publish
-	OnDone func(PublishDoneTrace)
+	OnDone func(context.Context, PublishDoneTrace)
 }
 
-func (p *PublishStartTrace) done(err error) {
+func (p *PublishStartTrace) done(ctx context.Context, err error) {
 	if p == nil || p.OnDone == nil {
 		return
 	}
-	p.OnDone(PublishDoneTrace{
+	p.OnDone(ctx, PublishDoneTrace{
 		Error: err,
 	})
 }
@@ -43,7 +43,7 @@ func (c *Client) tracePublish(ctx context.Context, p *packets.Publish) *PublishS
 }
 
 type RecvStartTrace struct {
-	OnDone func(RecvDoneTrace)
+	OnDone func(context.Context, RecvDoneTrace)
 }
 
 type RecvDoneTrace struct {
@@ -62,11 +62,11 @@ func (c *Client) traceRecv(ctx context.Context) *RecvStartTrace {
 	return &t
 }
 
-func (t *RecvStartTrace) done(x interface{}, err error) {
+func (t *RecvStartTrace) done(ctx context.Context, x interface{}, err error) {
 	if t == nil || t.OnDone == nil {
 		return
 	}
-	t.OnDone(RecvDoneTrace{
+	t.OnDone(ctx, RecvDoneTrace{
 		Packet:     x,
 		PacketType: matchPacketType(x),
 		Error:      err,
@@ -77,7 +77,7 @@ type SendStartTrace struct {
 	Packet     interface{}
 	PacketType packets.PacketType
 
-	OnDone func(SendDoneTrace)
+	OnDone func(context.Context, SendDoneTrace)
 }
 
 type SendDoneTrace struct {
@@ -97,9 +97,9 @@ func (c *Client) traceSend(ctx context.Context, x interface{}) *SendStartTrace {
 	return &t
 }
 
-func (t *SendStartTrace) done(err error) {
+func (t *SendStartTrace) done(ctx context.Context, err error) {
 	if t != nil && t.OnDone != nil {
-		t.OnDone(SendDoneTrace{
+		t.OnDone(ctx, SendDoneTrace{
 			Error: err,
 		})
 	}


### PR DESCRIPTION
enables passing the context to the trace functions

NOTE: this is a breaking change, the cloud kit is updated here
https://github.com/netdata/cloud-kit/pull/190