### PR TITLE
Unsubscribe packet missing flags

### DIFF
--- a/packets/unsubscribe.go
+++ b/packets/unsubscribe.go
@@ -55,7 +55,7 @@ func (u *Unsubscribe) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (u *Unsubscribe) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: UNSUBSCRIBE}}
+	cp := &ControlPacket{FixedHeader: FixedHeader{Type: UNSUBSCRIBE, Flags: 2}}
 	cp.Content = u
 
 	return cp.WriteTo(w)


### PR DESCRIPTION
I noticed that we couldn't unsubscribe, we get a `paho: client closed` error. After some digging I found out that this was fixed in the main repo with [this commit](https://github.com/eclipse/paho.golang/commit/9638458a263ed04d87c32631ecfa5f33485d7938) which fixed [this issue](https://github.com/eclipse/paho.golang/issues/30).

We also have an issue related to this: https://github.com/netdata/product/issues/1742
Of course working towards merging is the right way to do this but for now I'm just bringing this single bugfix in so that I can unlock the development of the MQTT lost session service.